### PR TITLE
Add documentation link to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,23 @@
 = Megatron
 
+This is the repository for the {RubyGem Megatron}[https://rubygems.org/gems/megatron], a
+UI framework for providing consistent styles across multiple applications.
+
+Documentation for using the gem can be found at: https://megatron-docs.compose.io
+
+
+== Setup
+
+This package has both rubygems and node package manager dependencies. To install:
+
+  npm install
+  bundle install
+
+Once dependencies are installed, you should be able to run:
+
+  make install
+
+
+== License
+
 This project rocks and uses MIT-LICENSE.


### PR DESCRIPTION
Hello.

Landing at the frontpage for the gem on GitHub, there is no information about the gem is or its purpose. Just a small PR to add a brief intro, documentation link, and some hints on getting the gem setup locally.