### PR TITLE
Elements that need to respond to toggling have no way of doing so

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gemspec
 
 gem 'sass', '~> 3.3', '>= 3.3.4'
 gem 'rack-cors'
-gem 'puma'
+gem 'puma', '~> 2.16.0'
 gem 'sass-rails', '5.0.3'
 gem 'kramdown'
 gem 'autoprefixer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    megatron (0.1.73)
+    megatron (0.1.76)
       block_helpers (~> 0.3.3)
       esvg (~> 2.8)
       gaffe (~> 1)
@@ -84,7 +84,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.99)
+    mime-types (2.99.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
     nokogiri (1.6.6.2)
@@ -97,7 +97,7 @@ GEM
     pry-byebug (3.2.0)
       byebug (~> 5.0)
       pry (~> 0.10)
-    puma (2.12.3)
+    puma (2.16.0)
     rack (1.6.4)
     rack-cors (0.4.0)
     rack-test (0.6.3)
@@ -199,7 +199,7 @@ DEPENDENCIES
   listen (~> 3.0)
   megatron!
   pry-byebug
-  puma
+  puma (~> 2.16.0)
   rack-cors
   rails_12factor
   rspec-rails (~> 3.3.0)

--- a/app/assets/javascripts/megatron/utils/text-helpers.js
+++ b/app/assets/javascripts/megatron/utils/text-helpers.js
@@ -50,7 +50,7 @@ var TextHelpers = {
     }
     Array.prototype.forEach.call(document.querySelectorAll('textarea:not(.no-auto-size)'), autoHeight)
 
-    bean.on(document.querySelector('body'), 'keyup', 'textarea', function(event){
+    bean.on(document.querySelector('body'), 'keyup toggler:show', 'textarea', function(event){
       autoHeight(event.currentTarget)
     })
   },


### PR DESCRIPTION
I've added event dispatching from the Toggle component that fires events to which other components and libraries can respond. I'm using this with the text autosizing component to autosize textareas that reside inside containers that initially start hidden and become visible by way of toggling.