### PR TITLE
Fix rubygems push (again)

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-echo "---\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
-chmod 0600 ~/.gem/credentials
-
-echo '+++ Upload to rubygems'
-gem push megatron-`bundle exec ruby -e 'puts Gem.loaded_specs["megatron"].version'`.gem
-
-rm ~/.gem/credentials
+curl --data-binary @megatron-`bundle exec ruby -e 'puts Gem.loaded_specs["megatron"].version'`.gem \
+  -H "Authorization:$RUBYGEMS_API_KEY" \
+  -H "Content-Type: application/octet-stream" \
+  https://rubygems.org/api/v1/gems

--- a/lib/megatron/version.rb
+++ b/lib/megatron/version.rb
@@ -1,3 +1,3 @@
 module Megatron
-  VERSION = "0.2.25"
+  VERSION = "0.2.26".freeze
 end


### PR DESCRIPTION
Specifying a `Content-Type` header seems to fix the gem push process. I have no idea why it's required, when the documentation explicitly doesn't include it:

http://guides.rubygems.org/rubygems-org-api/#gem-methods
> POST - /api/v1/gems
> 
> Submit a gem to RubyGems.org. Must post a built RubyGem in the request body.
> 
> ```
> $ curl --data-binary @gemcutter-0.2.1.gem \
>        -H 'Authorization:701243f217cdf23b1370c7b66b65ca97' \
>        https://rubygems.org/api/v1/gems
> 
> Successfully registered gem: gemcutter (0.2.1)
> ```

:shrug: