### PR TITLE
Easily convert a textarea to a CodeMirror editor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    megatron (0.2.28)
+    megatron (0.2.29)
       block_helpers (~> 0.3.3)
       esvg (~> 2.8)
       gaffe (~> 1)

--- a/app/assets/javascripts/megatron/index.js
+++ b/app/assets/javascripts/megatron/index.js
@@ -5,20 +5,10 @@ var dialog = require('compose-dialog')
 var toggler = require('compose-toggler')
 var form = require('compose-remote-form') // Our UJS implementation
 var esvg = require('./esvg')
-var highlighter = require('compose-code-highlighter')
+var code = require('./code')
 
 // Use Dialog for remote-form confirmation dialogs
 form.confirm = dialog.show
-
-// CodeMirror Settings
-var CodeMirror = require('codemirror')
-require('codemirror/mode/htmlmixed/htmlmixed')
-require('codemirror/mode/slim/slim')
-require('codemirror/mode/javascript/javascript')
-require('codemirror/mode/css/css')
-require('codemirror/mode/sql/sql')
-require('codemirror/addon/runmode/runmode.js')
-require('codemirror/addon/edit/matchbrackets.js')
 
 var timeToggle = require('compose-time-toggle') // Switch time elements between local and UTC
 require('compose-slider')      // Our slider (range input) component
@@ -28,8 +18,6 @@ require('./utils/auto-navigate')
 require('./utils/clipboard')
 require('./utils/form-flash')
 require('./utils/form-response')
-CodeMirror.highlighter = highlighter
-CodeMirror.highlight = highlighter.highlight
 var popMessage = require('./utils/messages')
 require('./utils/text-helpers')
 require('./utils/progress-bar')
@@ -42,7 +30,7 @@ event.ready(function() {
 })
 
 event.change(function(){
-  CodeMirror.highlight()
+  code.setup()
 })
 
 window.Megatron = module.exports = {

--- a/app/assets/javascripts/megatron/index.js
+++ b/app/assets/javascripts/megatron/index.js
@@ -2,10 +2,10 @@ var event = require('compose-event')
 var notify = require('compose-notification')
 var request = require('superagent')
 var dialog = require('compose-dialog')
+var code = require('./utils/code')
 var toggler = require('compose-toggler')
 var form = require('compose-remote-form') // Our UJS implementation
 var esvg = require('./esvg')
-var code = require('./code')
 
 // Use Dialog for remote-form confirmation dialogs
 form.confirm = dialog.show
@@ -40,7 +40,7 @@ window.Megatron = module.exports = {
   form: form,
   request: request,
   esvg: esvg,
-  code: CodeMirror,
+  code: code,
   toggler: toggler,
   timeToggle: timeToggle,
   popMessage: popMessage

--- a/app/assets/javascripts/megatron/utils/code.js
+++ b/app/assets/javascripts/megatron/utils/code.js
@@ -1,0 +1,55 @@
+var highlighter = require('compose-code-highlighter')
+
+CodeMirror.highlighter = highlighter
+CodeMirror.highlight = highlighter.highlight
+// CodeMirror Settings
+var CodeMirror = require('codemirror')
+require('codemirror/mode/htmlmixed/htmlmixed')
+require('codemirror/mode/slim/slim') require('codemirror/mode/javascript/javascript')
+require('codemirror/mode/css/css')
+require('codemirror/mode/sql/sql')
+require('codemirror/addon/runmode/runmode.js')
+require('codemirror/addon/edit/matchbrackets.js')
+
+highlighter.addAlias({ pgsql: 'text/x-pgsql' })
+
+var editorDefaults = {
+  indent: 2,
+  matchBrackets: true,
+  lineWrapping: true
+}
+
+function getOptions ( el ) {
+  var lang = highlighter.aliasLang( el.dataset.lang || 'plain' ),
+
+  return {
+    mode: lang,
+    indent: el.dataset.indent,
+    lineWrapping: el.dataset.wrap,
+    matchBrackets: el.dataset.matchBrackets
+  }
+}
+
+function newEditor ( el ) {
+  var options = Object.assign( {}, editorDefaults, getOptions( el ))
+
+  CodeMirror.fromTextArea( el, options )
+}
+
+function setup (){
+
+  highlighter.highlight()
+
+  var inputs = document.querySelector('textarea[data-lang]')
+  Array.prototype.forEach.call( inputs, newEditor )
+}
+
+
+var code = CodeMirror
+code.highlighter = highlighter
+code.highlight = highlighter.highlight
+code.addAlias = highlighter.addAlias
+code.getMode = highlighter.aliasLang
+code.setup = setup
+
+module.exports = code

--- a/app/assets/javascripts/megatron/utils/code.js
+++ b/app/assets/javascripts/megatron/utils/code.js
@@ -1,17 +1,16 @@
-var highlighter = require('compose-code-highlighter')
+var highlighter = require( 'compose-code-highlighter' )
 
-CodeMirror.highlighter = highlighter
-CodeMirror.highlight = highlighter.highlight
 // CodeMirror Settings
 var CodeMirror = require('codemirror')
-require('codemirror/mode/htmlmixed/htmlmixed')
-require('codemirror/mode/slim/slim') require('codemirror/mode/javascript/javascript')
-require('codemirror/mode/css/css')
-require('codemirror/mode/sql/sql')
-require('codemirror/addon/runmode/runmode.js')
-require('codemirror/addon/edit/matchbrackets.js')
+require( 'codemirror/mode/htmlmixed/htmlmixed' )
+require( 'codemirror/mode/slim/slim' )
+require( 'codemirror/mode/javascript/javascript' )
+require( 'codemirror/mode/css/css' )
+require( 'codemirror/mode/sql/sql' )
+require( 'codemirror/addon/runmode/runmode.js' )
+require( 'codemirror/addon/edit/matchbrackets.js' )
 
-highlighter.addAlias({ pgsql: 'text/x-pgsql' })
+highlighter.addAlias( { pgsql: 'text/x-pgsql' } )
 
 var editorDefaults = {
   indent: 2,
@@ -20,7 +19,7 @@ var editorDefaults = {
 }
 
 function getOptions ( el ) {
-  var lang = highlighter.aliasLang( el.dataset.lang || 'plain' ),
+  var lang = highlighter.aliasLang( el.dataset.lang || 'plain' )
 
   return {
     mode: lang,
@@ -30,8 +29,9 @@ function getOptions ( el ) {
   }
 }
 
-function newEditor ( el ) {
-  var options = Object.assign( {}, editorDefaults, getOptions( el ))
+function newEditor ( el, options ) {
+  options = options || {}
+  options = Object.assign( {}, editorDefaults, getOptions( el ))
 
   CodeMirror.fromTextArea( el, options )
 }
@@ -40,7 +40,7 @@ function setup (){
 
   highlighter.highlight()
 
-  var inputs = document.querySelector('textarea[data-lang]')
+  var inputs = document.querySelectorAll('textarea[data-lang]')
   Array.prototype.forEach.call( inputs, newEditor )
 }
 
@@ -49,7 +49,8 @@ var code = CodeMirror
 code.highlighter = highlighter
 code.highlight = highlighter.highlight
 code.addAlias = highlighter.addAlias
-code.getMode = highlighter.aliasLang
+code.aliasLang = highlighter.aliasLang
+code.newEditor = newEditor
 code.setup = setup
 
 module.exports = code

--- a/lib/megatron/version.rb
+++ b/lib/megatron/version.rb
@@ -1,3 +1,3 @@
 module Megatron
-  VERSION = "0.2.28".freeze
+  VERSION = "0.2.29".freeze
 end


### PR DESCRIPTION
Add `data-lang="pgsql"` to a textarea to convert it to a syntax highlighted code editor for postgresql. Many other languages work too.