### PR TITLE
add json error responder

### DIFF
--- a/app/controllers/megatron/errors_controller.rb
+++ b/app/controllers/megatron/errors_controller.rb
@@ -1,5 +1,18 @@
+# coding: utf-8
 module Megatron
   class ErrorsController < ActionController::Base
+    JSON_RESPONSES = {
+      internal_server_error: "an unexpected error occurred",
+      bad_request:           "bad request",
+      forbidden:             "forbidden",
+      method_not_allowed:    "method not supported",
+      not_acceptable:        "not acceptable",
+      not_found:             "not found",
+      not_implemented:       "not implemented",
+      unauthorized:          "unauthorized",
+      unprocessable_entity:  "we couldn't process your input"
+    }.freeze
+
     include Gaffe::Errors
 
     # Override 'error' layout
@@ -8,9 +21,14 @@ module Megatron
     # Render the correct template based on the exception “standard” code.
     # Eg. For a 404 error, the `errors/not_found` template will be rendered.
     def show
-      # Here, the `@exception` variable contains the original raised error
-      render "megatron/errors/#{@rescue_response}", status: @status_code
+      respond_to do |format|
+        format.html {
+          # Here, the `@exception` variable contains the original raised error
+          render "megatron/errors/#{@rescue_response}", status: @status_code
+        }
+        format.json {
+          render json: { errors: JSON_RESPONSES[@rescue_response] }, status: @status_code
+        }
     end
   end
 end
-


### PR DESCRIPTION
Megatron hijacks the error responses for JSON-based requests and returns HTML, which isn't ideal. This adds a JSON responder for error conditions with some simple messaging.