### PR TITLE
Runs specs during kite build; add specs for ErrorsController

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -8,6 +8,9 @@ make clean
 echo '+++ Build'
 make build
 
+echo '+++ Test'
+bundle exec rspec
+
 echo '+++ Upload'
 bundle exec rake megatron:upload
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/
 
 /app/assets/javascripts/megatron/esvg.js
 error_pages.zip
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ docs/
 
 /app/assets/javascripts/megatron/esvg.js
 error_pages.zip
-.idea

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,9 @@ group :development, :test do
 end
 
 group :test do
-  gem 'combustion', '~> 0.5.3'
+  gem 'rspec-core', '~> 3.3.2'
   gem 'rspec-rails', '~> 3.3.0'
+  gem 'combustion', '~> 0.5.3'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ DEPENDENCIES
   puma (~> 2.16.0)
   rack-cors
   rails_12factor
+  rspec-core (~> 3.3.2)
   rspec-rails (~> 3.3.0)
   s3
   sass (~> 3.3, >= 3.3.4)
@@ -210,4 +211,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,12 @@ end
 
 require 'rdoc/task'
 
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
+
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = 'Megatron'

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+class Megatron::Forbidden < StandardError
+end
+
+class Megatron::Unauthorized < StandardError
+end
+
+describe Megatron::ErrorsController do
+  describe '#show' do
+    let(:request) { test_request }
+    let(:env) do
+      request.env.merge({
+        'action_dispatch.exception' => exception,
+        'HTTP_ACCEPT' => 'application/json'
+      })
+    end
+    let(:status) { response.first }
+    let(:body) { response.last.body }
+
+    let(:response) do
+      Gaffe.errors_controller_for_request(env).action(:show).call(env)
+    end
+
+    context 'with internal_server_error' do
+      let(:exception) { StandardError.new }
+      it { expect(status).to eql 500 }
+      it { expect(body).to match(/an unexpected error occurred/) }
+    end
+
+    context 'with bad_request' do
+      let(:exception) { ActionController::BadRequest.new }
+      it { expect(status).to eql 400 }
+      it { expect(body).to match(/bad request/) }
+    end
+
+    context 'with forbidden' do
+      let(:exception) { Megatron::Forbidden.new }
+      it { expect(status).to eql 403 }
+      it { expect(body).to match(/forbidden/) }
+    end
+
+    context 'with method_not_allowed' do
+      let(:exception) { ActionController::MethodNotAllowed.new(:foo) }
+      it { expect(status).to eql 405 }
+      it { expect(body).to match(/method not supported/) }
+    end
+
+    context 'with not_acceptable' do
+      let(:exception) { ActionController::UnknownFormat.new }
+      it { expect(status).to eql 406 }
+      it { expect(body).to match(/not acceptable/) }
+    end
+
+    context 'with not_found' do
+      let(:exception) { ActionController::RoutingError.new('blah') }
+      it { expect(status).to eql 404 }
+      it { expect(body).to match(/not found/) }
+    end
+
+    context 'with not_implemented' do
+      let(:exception) { ActionController::NotImplemented.new }
+      it { expect(status).to eql 501 }
+      it { expect(body).to match(/not implemented/) }
+    end
+
+    context 'with unauthorized' do
+      let(:exception) { Megatron::Unauthorized.new }
+      it { expect(status).to eql 401 }
+      it { expect(body).to match(/unauthorized/) }
+    end
+
+    context 'with unprocessable_entity' do
+      let(:exception) { ActionController::InvalidAuthenticityToken.new }
+      it { expect(status).to eql 422 }
+      it { expect(body).to match(/we couldn't process your input/) }
+    end
+  end
+end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -7,6 +7,17 @@ class Megatron::Unauthorized < StandardError
 end
 
 describe Megatron::ErrorsController do
+  before do
+    module ActionDispatch
+      class ExceptionWrapper
+        @@rescue_responses.merge!(
+            'Megatron::Unauthorized' => :unauthorized,
+            'Megatron::Forbidden' => :forbidden
+        )
+      end
+    end
+  end
+
   describe '#show' do
     let(:request) { test_request }
     let(:env) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,15 +11,6 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 end
 
-module ActionDispatch
-  class ExceptionWrapper
-    @@rescue_responses.merge!(
-        'Megatron::Unauthorized' => :unauthorized,
-        'Megatron::Forbidden' => :forbidden
-    )
-  end
-end
-
 def test_request
   if Rails::VERSION::MAJOR >= 5
     ActionDispatch::TestRequest.create

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,20 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
 end
+
+module ActionDispatch
+  class ExceptionWrapper
+    @@rescue_responses.merge!(
+        'Megatron::Unauthorized' => :unauthorized,
+        'Megatron::Forbidden' => :forbidden
+    )
+  end
+end
+
+def test_request
+  if Rails::VERSION::MAJOR >= 5
+    ActionDispatch::TestRequest.create
+  else
+    ActionDispatch::TestRequest.new
+  end
+end


### PR DESCRIPTION
This patch adds a step to the buildkite configuration to run specs. It also adds specs to test the JSON-specific behavior of `ErrorsController`.