### PR TITLE
Allow controllers to override “fullpath” when rendering nav items

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    megatron (0.3.2)
+    megatron (0.3.4)
       block_helpers (~> 0.3.3)
       cyborg
       gaffe (~> 1)

--- a/app/helpers/megatron/application_helper.rb
+++ b/app/helpers/megatron/application_helper.rb
@@ -24,17 +24,16 @@ module Megatron
 
     def test_current_page(criteria)
       return false unless criteria.present?
-      
+
       test_params = criteria.delete(:params) || {}
       [:controller, :action, :path].each do |k|
         test_params[k] ||= criteria[k] if criteria[k].present?
       end
 
-      fullpath = parse_url(request.fullpath)
+      fullpath = parse_url(controller.try(:fullpath) || request.fullpath)
       check_params = params.to_unsafe_hash.symbolize_keys.merge(path: fullpath)
 
       test_params.all? {|k, v| test_here_key_value(k, v, check_params) }
-
     end
 
     def parse_url(path)

--- a/lib/megatron/version.rb
+++ b/lib/megatron/version.rb
@@ -1,3 +1,3 @@
 module Megatron
-  VERSION = "0.3.3".freeze
+  VERSION = "0.3.4".freeze
 end


### PR DESCRIPTION
We need to render navigation items for a path other than the current path, e.g. when integrating the Enterprise databrowser with the common app stack. 

This PR adds a patch point that allows controllers to override the path used to determine if navigation items are active, so that navigation rendered for an alternate path can be done with the correct highlighting.