### PR TITLE
Move `embed_svg` from site ApplicationHelper into Megatron::ApplicationHelper and disambiguate from esvg's `embed_svg`

### DIFF
--- a/app/helpers/megatron/application_helper.rb
+++ b/app/helpers/megatron/application_helper.rb
@@ -62,7 +62,7 @@ module Megatron
       ENV["ROOT_URL"] || '/'
     end
 
-    def embed_svg(filename, options = {})
+    def inject_svg(filename, options = {})
       group = 0
       file = File.read(Megatron::Engine.root.join('app', 'assets', 'images', 'megatron', filename))
         .gsub(/<!--.+-->/, '')

--- a/app/helpers/megatron/application_helper.rb
+++ b/app/helpers/megatron/application_helper.rb
@@ -24,7 +24,7 @@ module Megatron
 
     def test_current_page(criteria)
       return false unless criteria.present?
-      
+
       test_params = criteria.delete(:params) || {}
       [:controller, :action, :path].each do |k|
         test_params[k] ||= criteria[k] if criteria[k].present?
@@ -60,6 +60,34 @@ module Megatron
 
     def get_root_url
       ENV["ROOT_URL"] || '/'
+    end
+
+    def embed_svg(filename, options = {})
+      group = 0
+      file = File.read(Megatron::Engine.root.join('app', 'assets', 'images', 'megatron', filename))
+        .gsub(/<!--.+-->/, '')
+        .gsub(/^\t{2,}\s*<\/?g>/, '')
+        .gsub(/width=".+?"/, 'width="312"')
+        .gsub(/\sheight.+$/, '')
+        .gsub(/\t/, '  ')
+        .gsub(/\n{3,}/m, "\n")
+        .gsub(/^\s{2}<g>.+?^\s{2}<\/g>/m) { |g|
+          g.gsub(/^\s{4,}\s+/, '    ')
+        }
+        .gsub(/^<g>.+?^<\/g>/m) { |g|
+          group += 1
+          count = 0
+          g.gsub(/^\s{2}<g>/) { |g|
+            count += 1
+            %Q{  <g id="group-#{group}-cube-#{count}">}
+          }
+        }
+      # doc = Nokogiri::HTML::DocumentFragment.parse file
+      # svg = doc.at_css 'svg'
+      # if options[:class].present?
+      #   svg['class'] = options[:class]
+      # end
+      file.html_safe
     end
   end
 end

--- a/app/views/layouts/megatron/errors.html.slim
+++ b/app/views/layouts/megatron/errors.html.slim
@@ -9,7 +9,7 @@ html.error-layout lang='en'
 
   body
     .error-page class="error-#{@status_code} #{('reverse-stack' if @status_code == 404)}"
-      = embed_svg("#{@status_code}.svg")
+      = inject_svg("#{@status_code}.svg")
       .error-message
         = yield
       footer.support-links

--- a/lib/megatron/version.rb
+++ b/lib/megatron/version.rb
@@ -1,3 +1,3 @@
 module Megatron
-  VERSION = "0.3.10".freeze
+  VERSION = "0.3.11".freeze
 end

--- a/site/app/helpers/application_helper.rb
+++ b/site/app/helpers/application_helper.rb
@@ -1,29 +1,2 @@
 module ApplicationHelper
-  def embed_svg(filename, options = {})
-    group = 0
-    file = File.read(Megatron::Engine.root.join('app', 'assets', 'images', 'megatron', filename))
-      .gsub(/<!--.+-->/, '')
-      .gsub(/^\t{2,}\s*<\/?g>/, '')
-      .gsub(/width=".+?"/, 'width="312"')
-      .gsub(/\sheight.+$/, '')
-      .gsub(/\t/, '  ')
-      .gsub(/\n{3,}/m, "\n")
-      .gsub(/^\s{2}<g>.+?^\s{2}<\/g>/m) { |g| 
-        g.gsub(/^\s{4,}\s+/, '    ')
-      }
-      .gsub(/^<g>.+?^<\/g>/m) { |g|
-        group += 1
-        count = 0
-        g.gsub(/^\s{2}<g>/) { |g| 
-          count += 1
-          %Q{  <g id="group-#{group}-cube-#{count}">}
-        }
-      }
-    # doc = Nokogiri::HTML::DocumentFragment.parse file
-    # svg = doc.at_css 'svg'
-    # if options[:class].present?
-    #   svg['class'] = options[:class]
-    # end
-    file.html_safe
-  end
 end


### PR DESCRIPTION
This PR moves the `embed_svg` method from `site/` `ApplicationHelper` into `Megatron::ApplicationHelper`.

Since `embed_svg` is [used by the error pages](https://github.com/compose-ui/megatron.rb/blob/embed-svg/app/views/layouts/megatron/errors.html.slim#L12), it needs to be accessible to all applications that use Megatron and not just the demo site. Otherwise the error pages render an unstyled "500 Internal Error, if you're the administrator of this application please check the logs" page with the following error in the logs:
```
Error during failsafe response: undefined method `embed_svg' for #<#<Class:0x00000009909788>:0x0000000a428088> /var/lib/gems/2.2.0/gems/megatron-0.3.10/app/views/layouts/megatron/errors.html.slim:12
```