### PR TITLE
Messages need to load on staging servers too

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    megatron (0.3.12)
+    megatron (0.3.13)
       block_helpers (~> 0.3.3)
       cyborg
       gaffe (~> 1)
@@ -186,4 +186,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/assets/javascripts/megatron/utils/messages.js
+++ b/app/assets/javascripts/megatron/utils/messages.js
@@ -116,7 +116,7 @@ var Messages = {
   },
 
   load: function messagesLoad(){
-    if(window.location.hostname.match(/app\.compose/)){
+    if(window.location.hostname.match(/app(.*)\.compose/)){
       var message = window.Megatron.accountMessage
       if(!message) {
         Messages.fetch()

--- a/app/views/layouts/megatron/default.html.slim
+++ b/app/views/layouts/megatron/default.html.slim
@@ -13,7 +13,7 @@ html lang="en"
 
   body
     - if content_for?(:blank)
-      
+
       = yield :blank
 
     - else
@@ -66,6 +66,10 @@ html lang="en"
                     .main-content
                       = render 'megatron/shared/main_content'
 
+                      - if params[:debug] == 'true' && !Rails.env.production?
+                        = Rails.application.class.parent_name rescue nil
+                        = debug(params.except :debug)
+
                     .main-sidebar
                       = yield :sidebar
 
@@ -76,6 +80,6 @@ html lang="en"
                   .main
                     = render 'megatron/shared/main_content'
 
-  - if params[:debug] == 'true' && !Rails.env.production?
-    = Rails.application.class.parent_name rescue nil
-    = debug(params.except :debug)
+                    - if params[:debug] == 'true' && !Rails.env.production?
+                      = Rails.application.class.parent_name rescue nil
+                      = debug(params.except :debug)

--- a/app/views/layouts/megatron/default.html.slim
+++ b/app/views/layouts/megatron/default.html.slim
@@ -75,3 +75,7 @@ html lang="en"
 
                   .main
                     = render 'megatron/shared/main_content'
+
+  - if params[:debug] == 'true' && !Rails.env.production?
+    = Rails.application.class.parent_name rescue nil
+    = debug(params.except :debug)

--- a/lib/megatron/version.rb
+++ b/lib/megatron/version.rb
@@ -1,3 +1,3 @@
 module Megatron
-  VERSION = "0.3.12".freeze
+  VERSION = "0.3.13".freeze
 end


### PR DESCRIPTION
The current matching regex only loads messages on local development machines and in production. We need to see the messages on staging servers as well.