### PR TITLE
Handle message URLs better

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    megatron (0.3.14)
+    megatron (0.3.15)
       block_helpers (~> 0.3.3)
       cyborg
       gaffe (~> 1)

--- a/app/assets/javascripts/megatron/utils/messages.js
+++ b/app/assets/javascripts/megatron/utils/messages.js
@@ -14,29 +14,27 @@ var Messages = {
     request.get('/messages.json').end(this.end.bind(this));
   },
 
-  link: function messagesDismiss(event){
-    var url = event.currentTarget.getAttribute('href'),
+  link: function messagesLink(event){
+    var messageUrl = event.currentTarget.getAttribute('href'),
+      messageApiUrl = event.currentTarget.getAttribute('data-api-url'),
       tokenMeta = document.querySelector('meta[name="csrf-token"]'),
-      token = tokenMeta && tokenMeta.getAttribute('content'),
-      self = this;
+      token = tokenMeta && tokenMeta.getAttribute('content');
 
     event.preventDefault()
     event.stopPropagation()
 
     request
-      .patch(url)
+      .patch(messageApiUrl)
       .set('X-CSRF-Token', token)
       .end(function(error, response){
         if (error || response.serverError) {
           return
         }
-        if (response.body) {
-          window.location = response.body.url
-        }
+        window.location = messageUrl
       })
   },
 
-  dismiss: function messagesLink(event){
+  dismiss: function messagesDismiss(event){
     var url = event.currentTarget.getAttribute('href'),
       tokenMeta = document.querySelector('meta[name="csrf-token"]'),
       token = tokenMeta && tokenMeta.getAttribute('content'),
@@ -90,7 +88,7 @@ var Messages = {
 
     html += "<p>"
     if (message.url)
-      html += "<a href='/messages/"+message.id+"' class='link'>"+message.body+"</a>"
+      html += "<a href='"+message.url+"' data-api-url='/messages/"+message.id+"' class='link'>"+message.body+"</a>"
     else
       html += message.body
     html += "</p></div>"

--- a/lib/megatron/version.rb
+++ b/lib/megatron/version.rb
@@ -1,3 +1,3 @@
 module Megatron
-  VERSION = "0.3.14".freeze
+  VERSION = "0.3.15".freeze
 end


### PR DESCRIPTION
Change rendering messages with URLs such that the message
URL (the customer-facing URL) is set as the href, and the
API URL for the message is stored in a `data` attribute.

Change the message link click handler such that when a user
clicks on the URL, we first PATCH the API URL to dismiss the
message asynchronously, and then change to the customer-
facing message URL via JavaScript.

**Fixes Control/Command-clicks on the link**, which didn't work
properly, as the href was set to the API URL.